### PR TITLE
Potential fix for code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/src/nextlive/pages/api/project-structure.ts
+++ b/src/nextlive/pages/api/project-structure.ts
@@ -8,7 +8,12 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
   }
 
   try {
-    const baseDir = req.query.baseDir as string || 'src/nextlive';
+    const SAFE_ROOT = path.resolve('src/nextlive');
+    const baseDirInput = req.query.baseDir as string || '';
+    const baseDir = path.resolve(SAFE_ROOT, baseDirInput);
+    if (!baseDir.startsWith(SAFE_ROOT)) {
+      return res.status(403).json({ success: false, message: 'Access denied' });
+    }
     const depth = parseInt(req.query.depth as string) || 2;
 
     const getStructure = (dir: string, currentDepth: number): any => {


### PR DESCRIPTION
Potential fix for [https://github.com/next-live/nextlive/security/code-scanning/2](https://github.com/next-live/nextlive/security/code-scanning/2)

To fix the issue, we need to ensure that the `baseDir` path is validated and restricted to a safe root directory. This can be achieved by:
1. Defining a safe root directory (e.g., `SAFE_ROOT`).
2. Normalizing the `baseDir` path using `path.resolve` to remove any `..` segments.
3. Verifying that the normalized path starts with the `SAFE_ROOT` directory. If it does not, return a `403 Forbidden` response.

This approach ensures that the `baseDir` parameter cannot be used to access files outside the intended directory.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
